### PR TITLE
Update supported Content-Type to include application_xml

### DIFF
--- a/flask_gae_gcs.py
+++ b/flask_gae_gcs.py
@@ -232,11 +232,13 @@ def _upload_fields():
                 (field_name, `werkzeug.datastructures.FileStorage`)
     '''
     result = []
-
     content_type = request.headers.get('content-type')
     mime_type, _ = parse_header(content_type)
 
-    if mime_type in ('text/plain', 'text/csv'):
+    # special case for  application/xml; name="Sample 9.16.16.csv"
+    is_app_xml_sap = "application/xml" in content_type
+
+    if mime_type in ('text/plain', 'text/csv') or is_app_xml_sap:
         _, params = parse_header(
             request.headers.get('content-disposition', '')
         )

--- a/flask_gae_gcs_tests.py
+++ b/flask_gae_gcs_tests.py
@@ -129,6 +129,16 @@ class TestCase(gae_tests.TestCase):
     self.assertIsInstance(results, list)
     self.assertEquals(0, len(results), results)
 
+  def test_upload_returns_valid_file_result_for_application_xml(self):
+    response = app.test_client().post(
+      data='xxx',
+      path='/test_upload',
+      headers={'content-type': 'application/xml; name="Sample 9.16.16.csv'},
+      query_string={})
+    self.assertEqual(200, response.status_code)
+    results = json.loads(response.data)
+    self.assertIsInstance(results, list)
+    self.assertEquals(1, len(results), results)
 
 if __name__ == '__main__':
   unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
-flask==0.9
-blinker==1.8.3
+blinker==1.4
+Flask==0.9
+flask-gae-tests==1.0.2
+GoogleAppEngineCloudStorageClient==1.9.22.1
+Jinja2==2.8
+MarkupSafe==0.23
+PyYAML==3.12
+Werkzeug==0.11.11
+wheel==0.24.0


### PR DESCRIPTION
- We need to support `application_xml` content type with extra with name included.
- Update dependencies to run tests
- Update Blinker. 1.8 doesn't exist
